### PR TITLE
[FIX] Change shell to bash so [ can be read on Linux

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Set PYTHONPATH
 export PYTHONPATH=$PYTHONPATH:./


### PR DESCRIPTION
On linux (Colab & Ubuntu at least) that [ in the file gives an Error: unexpected operator.
Similar to [ https://unix.stackexchange.com/questions/45781/shell-script-fails-syntax-error-unexpected/45784#45784]( https://unix.stackexchange.com/questions/45781/shell-script-fails-syntax-error-unexpected/45784#45784)

I haven't tried it out on Mac hence I didn't want to directly commit.